### PR TITLE
fixed makefiles so they properly build static libraries

### DIFF
--- a/STM32G431KBTx/makefile
+++ b/STM32G431KBTx/makefile
@@ -156,7 +156,8 @@ vpath %.cpp $(sort $(dir $(CPP_SOURCES)))
 OBJECTS += $(addprefix $(OBJECTS_DIR)/,$(notdir $(ASM_SOURCES:.s=.o)))
 vpath %.s $(sort $(dir $(ASM_SOURCES)))
 
-PLATFORM_OBJECTS = $(addprefix $(OBJECTS_DIR)/,$(notdir $(PLATFORM_SOURCES:.c=.o)))
+PLATFORM_OBJECTS = $(addprefix $(OBJECTS_DIR)/,$(notdir $(PLATFORM_C_SOURCES:.c=.o)))
+PLATFORM_OBJECTS = $(addprefix $(OBJECTS_DIR)/,$(notdir $(PLATFORM_CPP_SOURCES:.cpp=.o)))
 
 $(OBJECTS_DIR)/%.o: %.c | $(BUILD_DIR)
 	$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(OBJECTS_DIR)/$(notdir $(<:.c=.lst)) $< -o $@

--- a/STM32G473CBTx/makefile
+++ b/STM32G473CBTx/makefile
@@ -166,7 +166,8 @@ vpath %.cpp $(sort $(dir $(CPP_SOURCES)))
 OBJECTS += $(addprefix $(OBJECTS_DIR)/,$(notdir $(ASM_SOURCES:.s=.o)))
 vpath %.s $(sort $(dir $(ASM_SOURCES)))
 
-PLATFORM_OBJECTS = $(addprefix $(OBJECTS_DIR)/,$(notdir $(PLATFORM_SOURCES:.c=.o)))
+PLATFORM_OBJECTS = $(addprefix $(OBJECTS_DIR)/,$(notdir $(PLATFORM_C_SOURCES:.c=.o)))
+PLATFORM_OBJECTS = $(addprefix $(OBJECTS_DIR)/,$(notdir $(PLATFORM_CPP_SOURCES:.cpp=.o)))
 
 $(OBJECTS_DIR)/%.o: %.c | $(BUILD_DIR)
 	$(CC) -c $(CFLAGS) -Wa,-a,-ad,-alms=$(OBJECTS_DIR)/$(notdir $(<:.c=.lst)) $< -o $@


### PR DESCRIPTION
Quick one line fix.

For future reference, we will know if the static library is built properly if we see all the correpsonding object files from the `platform` directory in the `.a` file.

![image](https://user-images.githubusercontent.com/58921459/199622816-e1946da1-2817-4f20-883e-44c038f7ffaf.png)
